### PR TITLE
feat: Implemented get logged doctor

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -130,3 +130,39 @@ paths:
           description: List of doctors
         '404':
           description: No doctors found
+
+  /staff/me:
+    get:
+      summary: Get authenticated doctor
+      tags:
+        - staff
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Authenticated doctor retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  _id:
+                    type: string
+                  name:
+                    type: string
+                  surname:
+                    type: string
+                  specialty:
+                    type: string
+                  dni:
+                    type: string
+                  clinicId:
+                    type: string
+                  email:
+                    type: string
+                  userId:
+                    type: string
+        '404':
+          description: Authenticated doctor not found
+        '400':
+          description: Error retrieving authenticated doctor

--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -69,6 +69,40 @@ export const register = async (req, res) => {
     res.status(400).json({ message: error.message });
   }
 }
+// Get me
+export const getMe = async (req, res) => {
+  try {
+    const userId = req.user.userId;
+    const doctor = await Doctor.findOne({ userId });
+
+    if (!doctor) {
+      logger.error('Authenticated doctor not found', {
+        method: req.method,
+        url: req.originalUrl,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
+        userId
+      });
+      return res.status(404).json({ message: 'Authenticated doctor not found' });
+    }
+
+    logger.info('Doctor retrieved successfully', {
+      method: req.method,
+      url: req.originalUrl,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
+      doctorId: doctor._id
+    });
+    res.status(200).json(doctor);
+  } catch (error) {
+    logger.error('Error retrieving authenticated doctor', {
+      method: req.method,
+      url: req.originalUrl,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
+      error: error.message
+    });
+    res.status(400).json({ message: 'Error retrieving authenticated doctor. Please try again later.' });
+  }
+}
+
 
 // Get by Id
 export const getDoctorById = async (req, res) => {

--- a/src/routes/doctorRoute.js
+++ b/src/routes/doctorRoute.js
@@ -1,11 +1,12 @@
 import express from 'express';
-import { register,getDoctorById, deleteDoctor,updateDoctorSpeciality, getDoctorsBySpeciality} from '../controllers/doctorController.js';
+import { register, getMe ,getDoctorById, deleteDoctor,updateDoctorSpeciality, getDoctorsBySpeciality} from '../controllers/doctorController.js';
 import { verifyAuth } from '../middleware/verifyAuth.js';
 import { verifyAdmin } from '../middleware/verifyAdmin.js';
 
 const router = express.Router();
 
 router.post('/register', verifyAuth, verifyAdmin, register);
+router.get('/me', verifyAuth, getMe);
 router.get('/clinic/:clinicId/speciality/:speciality?', getDoctorsBySpeciality);
 router.get('/:doctorId', getDoctorById);
 router.put('/:doctorId', verifyAuth, verifyAdmin, updateDoctorSpeciality);


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve the information of the currently authenticated doctor. The endpoint utilizes the authentication token to identify the logged-in user and fetch their details from the database.

## Changes Included:
- New Endpoint:
Added `GET ` `/staff/me` endpoint to retrieve the authenticated doctor's information.
Returns a `200 OK` status with the doctor's details if the doctor is found.
Returns a `404 Not Found` status with an appropriate error message if the doctor is not found.
Returns a `400 Bad Request` status with an error message if there is an issue retrieving the authenticated doctor.

## OpenAPI Documentation:
- Updated `openapi.yaml` to include the new `GET` `/staff/me` endpoint.