### PR TITLE
Hotfix: staff routes fixed

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -15,9 +15,9 @@ export default function () {
   app.use(express.urlencoded({ extended: true }));
   app.use(cookieParser());
 
-  app.use(process.env.API_PREFIX || '' + '/staff/', router);
+  app.use((process.env.API_PREFIX || '') + '/staff/', router);
 
-  app.get('/', (req, res) => {
+  app.get(`${process.env.API_PREFIX || ''}/`, (req, res) => {
     res.send('API funcionando correctamente');
   });
 


### PR DESCRIPTION
### Pull Request Description

#### Summary
This Pull Request includes updates to the `app.use` method in the `api.js` file to ensure that the `/staff` prefix is always used for routing. This change standardizes the base path for all staff-related routes, improving the organization and accessibility of the API endpoints.

#### Changes Made
1. **Update `app.use` Method**:
   - Modified the `app.use` method in the `api.js` file to always use the `/staff` prefix for routing.