### PR TITLE
Chore: mongodb staff renamed

### DIFF
--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -5,13 +5,13 @@ metadata:
     kompose.cmd: kompose convert -o kubernetes/
     kompose.version: 1.34.0 (cbf2835db)
   labels:
-    io.kompose.service: mongodb
-  name: mongodb
+    io.kompose.service: mongodb-staff
+  name: mongodb-staff
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: mongodb
+      io.kompose.service: mongodb-staff
   strategy:
     type: Recreate
   template:
@@ -20,22 +20,33 @@ spec:
         kompose.cmd: kompose convert -o kubernetes/
         kompose.version: 1.34.0 (cbf2835db)
       labels:
-        io.kompose.service: mongodb
+        io.kompose.service: mongodb-staff
     spec:
       containers:
         - env:
             - name: MONGO_INITDB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: auth-secrets
+                  name: staff-secrets
                   key: MONGOPASS
             - name: MONGO_INITDB_ROOT_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: auth-secrets
+                  name: staff-secrets
                   key: MONGOADMIN
           image: mongo:latest
           name: mongodb-staff
+          livenessProbe:
+            exec:
+              command:
+              - mongosh
+              - --eval
+              - 'db.runCommand("ping").ok' 
+              - localhost:27017/test
+              - --quiet
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
           ports:
             - containerPort: 27017
               protocol: TCP

--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -46,7 +46,6 @@ spec:
               - --quiet
             initialDelaySeconds: 15
             periodSeconds: 5
-            timeoutSeconds: 5
           ports:
             - containerPort: 27017
               protocol: TCP

--- a/kubernetes/mongodb-service.yaml
+++ b/kubernetes/mongodb-service.yaml
@@ -5,8 +5,8 @@ metadata:
     kompose.cmd: kompose convert -o kubernetes/
     kompose.version: 1.34.0 (cbf2835db)
   labels:
-    io.kompose.service: mongodb
-  name: mongodb
+    io.kompose.service: mongodb-staff
+  name: mongodb-staff
 spec:
   type: ClusterIP
   ports:
@@ -15,4 +15,4 @@ spec:
       port: 27017
       targetPort: 27017
   selector:
-    io.kompose.service: mongodb
+    io.kompose.service: mongodb-staff


### PR DESCRIPTION
## Description

mongodb svc and deployment have been renamed to mongodb-staff. It also has now livenessProbe