### PR TITLE
chore: changed loadbalancer to clusterip

### DIFF
--- a/kubernetes/staff-svc-service.yaml
+++ b/kubernetes/staff-svc-service.yaml
@@ -8,12 +8,11 @@ metadata:
     io.kompose.service: staff-svc
   name: staff-svc
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       name: "3007"
       port: 3007
       targetPort: 3007
-      nodePort: 30007
   selector:
     io.kompose.service: staff-svc


### PR DESCRIPTION
This pull request includes a change to the `kubernetes/staff-svc-service.yaml` file to modify the service type from `LoadBalancer` to `ClusterIP`.

* [`kubernetes/staff-svc-service.yaml`](diffhunk://#diff-c36cfc9176944b3f8eccee38ca0199430a8c5864b83351d33b615e5b972b9275L11-L17): Changed the service type from `LoadBalancer` to `ClusterIP` and removed the `nodePort` specification.